### PR TITLE
Limit padding-top on h5 to footer descendants

### DIFF
--- a/assets/scss/_newsletter.scss
+++ b/assets/scss/_newsletter.scss
@@ -24,7 +24,7 @@
   min-height: 500px;
   margin-bottom: 200px;
 }
-#topics h5{
+#topics footer h5{
   padding-top: 7rem;
 }
 .question {

--- a/assets/scss/_portal.scss
+++ b/assets/scss/_portal.scss
@@ -87,7 +87,7 @@
   margin-bottom: 200px;
 }
 
-#topics h5{
+#topics footer h5{
   padding-top: 7rem;
 }
 


### PR DESCRIPTION
related-to: https://dip.torproject.org/web/manual/issues/4.
Will need to update web/lego in web/manual to complete the fix.