### PR TITLE
Fix torproject.org/about/history/ is aligned to the left although the text is rtl

### DIFF
--- a/assets/scss/_portal.scss
+++ b/assets/scss/_portal.scss
@@ -7,7 +7,6 @@
   font-size: 22px;
   font-weight: 400;
   line-height: 36px;
-  text-align: left;
 }
 .preamble p {
   color: #777777;


### PR DESCRIPTION
This PR fixes [about/history/ is aligned to the left although the text is rtl](https://gitlab.torproject.org/torproject/web/tpo/-/issues/65).

Taking a page out of @emmapeel2 strategy in the response in the [Improve ltr support in new website thread](https://gitlab.torproject.org/torproject/web/tpo/-/issues/4), I noticed the .content class had the text-align: left styling which caused conflict because it was a child element in @hiromipaw modification fix. 

Below is the lektor-staging screenshot in the 
https://lektor-staging.torproject.org/tpo/staging/ar/about/history/ page -
![about-history-fixed](https://user-images.githubusercontent.com/44947175/79008823-0cf1f500-7b13-11ea-9243-b890d497a634.PNG)


------

I took the initiative to check the other portals' (community, lego, manual, and support) template files to see if the .content class was utilized; it was not. It did manage to be used in the /thank-you/ & /about/cy-pres/ pages. Regarding the arabic language, the fix made no changes to the /thank-you page; it did, however, fix the /about/cy-pres/ page (equivalent to the about/history/ page). 

Below is the lektor-staging screenshot in the https://lektor-staging.torproject.org/tpo/staging/ar/about/cy-pres/index.html page -
![about-cy-pres-fixed](https://user-images.githubusercontent.com/44947175/79008827-0f544f00-7b13-11ea-8bc1-312710cb0065.PNG)
